### PR TITLE
Fix path for catalogs

### DIFF
--- a/409/connector/localfile.html
+++ b/409/connector/localfile.html
@@ -641,7 +641,7 @@ the local file system of each worker.</p>
 <section id="configuration">
 <h2 id="configuration">Configuration<a class="headerlink" href="#configuration" title="Permalink to this heading">#</a></h2>
 <p>To configure the local file connector, create a catalog properties file under
-<code class="docutils literal notranslate"><span class="pre">etc/catalog</span></code> named, for example, <code class="docutils literal notranslate"><span class="pre">example.properties</span></code> with the following
+<code class="docutils literal notranslate"><span class="pre">etc/trino/catalog</span></code> named, for example, <code class="docutils literal notranslate"><span class="pre">example.properties</span></code> with the following
 contents:</p>
 <div class="highlight-text notranslate"><div class="highlight"><pre><span></span>connector.name=localfile
 </pre></div>


### PR DESCRIPTION
Maybe I'm misunderstanding something, but it appears that the path is `/etc/trino/catalog`, not `/etc/catalog`? Perhaps the `trino` directory was implied, but wouldn't be obvious to me.

I'm trying out trino from docker hub:
https://hub.docker.com/r/trinodb/trino

```
trino@f16b287faa89:/$ ll etc/trino/catalog/
total 24
drwxr-xr-x 2 trino trino 4096 Mar  4 00:13 ./
drwxr-xr-x 3 trino trino 4096 Mar  4 00:14 ../
-rw-r--r-- 1 trino trino   19 Mar  4 00:13 jmx.properties
-rw-r--r-- 1 trino trino   22 Mar  4 00:13 memory.properties
-rw-r--r-- 1 trino trino   45 Mar  4 00:13 tpcds.properties
-rw-r--r-- 1 trino trino   43 Mar  4 00:13 tpch.properties
```