### PR TITLE
order of coordinates in ST_Point reversed

### DIFF
--- a/446/_sources/functions/geospatial.md.txt
+++ b/446/_sources/functions/geospatial.md.txt
@@ -86,7 +86,7 @@ Array elements must not be `NULL` or empty.
 The returned geometry may not be simple and may contain duplicate points if input array has duplicates.
 :::
 
-:::{function} ST_Point(lat: double, lon: double) -> Point
+:::{function} ST_Point(lon: double, lat: double) -> Point
 Returns a geometry type point object with the given coordinate values.
 :::
 


### PR DESCRIPTION
order of coordinates in ST_Point() function should be lon, lat instead of lat, lon